### PR TITLE
Resolve `Error: Unsupported Ruby version 2.1 found in 'TargetRubyVersion'` on CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 AllCops:
   Exclude:
+    - 'vendor/bundle/**/*'
     - 'bin/**'
     - 'Rakefile'
     - 'toycol.gemspec'


### PR DESCRIPTION
When I run  the  step `Run the default task`, I've got an error on CI.

```
Running RuboCop...
/home/runner/work/toycol/toycol/vendor/bundle/ruby/3.0.0/gems/rainbow-3.0.0/.rubocop.yml: Warning: no department given for HashSyntax.
/home/runner/work/toycol/toycol/vendor/bundle/ruby/3.0.0/gems/rainbow-3.0.0/.rubocop.yml: Warning: no department given for MethodName.
/home/runner/work/toycol/toycol/vendor/bundle/ruby/3.0.0/gems/rainbow-3.0.0/.rubocop.yml: Warning: no department given for StringLiterals.
Error: RuboCop found unsupported Ruby version 2.1 in `TargetRubyVersion` parameter (in vendor/bundle/ruby/3.0.0/gems/rainbow-3.0.0/.rubocop.yml). 2.1-compatible analysis was dropped after version 0.57.
Supported versions: 2.5, 2.6, 2.7, 3.0, 3.1
RuboCop failed!
Error: Process completed with exit code 1.
```

To avoid this, exclude `'vendor/bundle/**/*'`.